### PR TITLE
Rogue backtick in configuration docs

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -3,7 +3,7 @@ Configuration
 
 .. _configuration:
 
-Liara is driven through configuration files. The main file is ``config.yaml``, which can reference other configuration files. To get the full default configuration, use ``liara create-config``. Nested configuration options can be either provided by actually nesting them in the ``YAML`` file, or by ```.`` as the separator. For example, the following two configurations are equivalent:
+Liara is driven through configuration files. The main file is ``config.yaml``, which can reference other configuration files. To get the full default configuration, use ``liara create-config``. Nested configuration options can be either provided by actually nesting them in the ``YAML`` file, or by ``.`` as the separator. For example, the following two configurations are equivalent:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Removes a rogue backtick in the start of the configuration docs, in the section that describes how the YAML syntax works.

PR created entirely from the GitHub UI, sorry for the poorly named branch!